### PR TITLE
Display export button if allowed

### DIFF
--- a/app/views/admin/application/index.html.erb
+++ b/app/views/admin/application/index.html.erb
@@ -45,7 +45,11 @@ It renders the `_table` partial to display details about the resources.
       [:new, namespace, page.resource_path],
       class: "button",
     ) if valid_action?(:new) && show_action?(:new, new_resource) %>
-    <%= link_to('Export', [:export, namespace, page.resource_name.to_s.pluralize, sanitized_order_params(page, :id).to_h.merge(format: :csv)], class: 'button') if valid_action?(:export) %>
+    <%= link_to(
+      'Export',
+      [:export, namespace, page.resource_name.to_s.pluralize, sanitized_order_params(page, :id).to_h.merge(format: :csv)],
+      class: 'button'
+    ) if valid_action?(:export) && show_action?(:export, resource_name) %>
   </div>
 </header>
 


### PR DESCRIPTION
The button should only show up if `show_action?(:export, resource_name)` returns true (which is the default implementation, but can be overridden e.g. by Punditize).

Similar to https://github.com/thoughtbot/administrate/pull/1591.