### PR TITLE
Updated index to work with administrate v0.16

### DIFF
--- a/app/views/admin/application/index.html.erb
+++ b/app/views/admin/application/index.html.erb
@@ -42,7 +42,7 @@ It renders the `_table` partial to display details about the resources.
         "administrate.actions.new_resource",
         name: page.resource_name.titleize.downcase
       ),
-      [:new, namespace, page.resource_path],
+      [:new, namespace, page.resource_path.to_sym],
       class: "button",
     ) if valid_action?(:new) && show_action?(:new, new_resource) %>
     <%= link_to(


### PR DESCRIPTION
Hi! Administrate has been updated to v0.16 and it includes a change to the `app/views/admin/application/index.html.erb`. Without it I was receiving an `ArgumentError` => "Please use symbols for polymorphic route arguments".

See: https://github.com/thoughtbot/administrate/pull/1972