### PR TITLE
Adding csv as a explicit dependency due to being removed from stdlib on ruby 3.4.0

### DIFF
--- a/administrate_exportable.gemspec
+++ b/administrate_exportable.gemspec
@@ -37,4 +37,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rails', '>= 4.2'
   spec.add_dependency 'actionview', '>= 5.2.2.1'
   spec.add_dependency 'railties', '>= 5.2.2.1'
+  spec.add_dependency 'csv', '~> 3.0'
 end


### PR DESCRIPTION
Solves issue #52 

Not sure what's your process to bump version (ie. if you want me to do it or you do it on master)